### PR TITLE
[feat] add usecase list page to footer if user not connected

### DIFF
--- a/templates/urbanvitaliz.fr/footer.html
+++ b/templates/urbanvitaliz.fr/footer.html
@@ -1,4 +1,7 @@
 {% load static %}
+{% load wagtailcore_tags %}
+{% wagtail_site as current_site %}
+
 <footer class="col-11 fr-py-6w">
     <hr />
     <div class="row fr-py-6w">
@@ -13,6 +16,13 @@
                 <li>
                     <a class="link-secondary" href="{% url 'whoweare' %}">Qui sommes-nous ?</a>
                 </li>
+                {% if not user.is_authenticated %}
+                    {% for menuitem in current_site.root_page.get_children.live.in_menu %}
+                    <li>
+                        <a class="link-secondary" href="{% pageurl menuitem %}">{{ menuitem.title }}</a>
+                    </li>
+                    {% endfor %}
+                {% endif %}
                 <li>
                     <a class="link-secondary" href="{% url 'followus' %}">Suivre le projet</a>
                 </li>


### PR DESCRIPTION
Ajout d'un lien dans le footer menant vers la page des cas d'usage lorsque l'utilisateur.ice n'est pas connecté.e.
En surcharge sur le portail UrbanVitaliz.

Cette PR est liée avec [cette PR de recoco](https://github.com/betagouv/recommandations-collaboratives/pull/733).