### PR TITLE
Ajout d'un bouton pour conseiller vers un guide d'utilisation

### DIFF
--- a/templates/urbanvitaliz.fr/home/regional_actors.html
+++ b/templates/urbanvitaliz.fr/home/regional_actors.html
@@ -10,7 +10,7 @@
     <link href="{% sass_src 'home/css/actors/actors.scss' %}"
           rel="stylesheet"
           type="text/css" />
-          <link href="{% sass_src 'urbanvitaliz.fr/home/css/home/regional_actors.scss' %}"
+    <link href="{% sass_src 'urbanvitaliz.fr/home/css/home/regional_actors.scss' %}"
           rel="stylesheet"
           type="text/css" />
 {% endblock %}
@@ -33,6 +33,9 @@
                         <li>
                             <a href="{% url 'home-contact' %}?subject=Demande d’accès à UrbanVitaliz en tant que conseiller·e"
                                class="fr-btn fr-text--xl">Demander un accès</a>
+                            <a href="https://urls.fr/XMxS6m"
+                               target="_blank"
+                               class="fr-btn fr-btn--secondary fr-text--xl"><span class="fr-icon-eye-fill fr-mr-1w" aria-hidden="true"></span>Guide d'utilisation du compte conseiller</a>
                         </li>
                     </ul>
                     <div>

--- a/templates/urbanvitaliz.fr/home/regional_actors.html
+++ b/templates/urbanvitaliz.fr/home/regional_actors.html
@@ -33,7 +33,7 @@
                         <li>
                             <a href="{% url 'home-contact' %}?subject=Demande d’accès à UrbanVitaliz en tant que conseiller·e"
                                class="fr-btn fr-text--xl">Demander un accès</a>
-                            <a href="https://urls.fr/XMxS6m"
+                            <a href="https://www.canva.com/design/DAGYcNZMMSk/KUTB327GiO4NXYNqkRkMnw/view?utm_content=DAGYcNZMMSk&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h4cf388dfe7"
                                target="_blank"
                                class="fr-btn fr-btn--secondary fr-text--xl"><span class="fr-icon-eye-fill fr-mr-1w" aria-hidden="true"></span>Guide d'utilisation du compte conseiller</a>
                         </li>


### PR DESCRIPTION
Ajout d'un bouton secondaire menant vers un guide d'utilisation pour conseiller.

Resolve [#](https://github.com/betagouv/recommandations-collaboratives/issues/918)