### PR TITLE
Modification du fichier d'aide au conseiller

### DIFF
--- a/templates/sosponts.recoconseil.fr/account/fragments/button_pending_advisor_request.html
+++ b/templates/sosponts.recoconseil.fr/account/fragments/button_pending_advisor_request.html
@@ -1,6 +1,5 @@
 <div class="d-flex justify-content-between align-items-center">
-    <a href="
-    "
+    <a href="https://github.com/user-attachments/files/21228001/guide.d.utilisation.SOS.Ponts.-.pour.les.conseillers.Externes_V3.pdf"
        target="_blank"
        class="fr-btn fr-btn w-50 justify-content-center">Télécharger le guide en pdf</a>
 </div>

--- a/templates/sosponts.recoconseil.fr/account/fragments/button_pending_advisor_request.html
+++ b/templates/sosponts.recoconseil.fr/account/fragments/button_pending_advisor_request.html
@@ -1,5 +1,6 @@
 <div class="d-flex justify-content-between align-items-center">
-    <a href="https://github.com/user-attachments/files/19452045/tuto.conseillers.SOS.Ponts.pdf"
+    <a href="
+    "
        target="_blank"
        class="fr-btn fr-btn w-50 justify-content-center">Télécharger le guide en pdf</a>
 </div>


### PR DESCRIPTION
Changement du fichier d'aide pour les conseillers à télécharger après la demande d'inscription avec le fichier ci-dessous :

[guide d'utilisation SOS Ponts - pour les conseillers Externes_V3.pdf](https://github.com/user-attachments/files/21228001/guide.d.utilisation.SOS.Ponts.-.pour.les.conseillers.Externes_V3.pdf)
